### PR TITLE
Conflicts in versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,11 @@
-huggingface-hub==0.0.12
-nltk==3.5
+huggingface-hub>=0.4.0
+nltk>=3.5
 numpy==1.23.2
 openai==0.23.0
 pandas==1.4.3
 rouge==1.0.1
 sentence-transformers==2.2.2
 transformers==4.21.1
-nltk==3.8
 evaluate==0.4.0
 rouge==1.0.1
 rouge_score==0.1.2


### PR DESCRIPTION


*Issue #, if available: Conflicting versions of nltk and huggingface-hub

*Description of changes:*

nltk is listed twice with hard requirements nltk==3.5 and nltk==3.8 and so it results in conflicts. and huggingface-hub results in the following error, so change it
 ERROR: Cannot install huggingface-hub==0.0.12 and sentence-transformers==2.2.2 because these package versions have conflicting dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
