### PR TITLE
Use f-strings for string formatting

### DIFF
--- a/utils_data.py
+++ b/utils_data.py
@@ -20,9 +20,9 @@ def load_data_std(args):
     for qid in problems:
         problems[qid]['caption'] = captions[qid] if qid in captions else ""
 
-    train_qids = pid_splits['%s' % (args.train_split)]
-    val_qids = pid_splits['%s' % (args.val_split)]
-    test_qids = pid_splits['%s' % (args.test_split)]
+    train_qids = pid_splits[f'{args.train_split}']
+    val_qids = pid_splits[f'{args.val_split}']
+    test_qids = pid_splits[f'{args.test_split}']
     print(f"number of train problems: {len(train_qids)}\n")
     print(f"number of val problems: {len(val_qids)}\n")
     print(f"number of test problems: {len(test_qids)}\n")
@@ -52,9 +52,9 @@ def load_data_img(args):
     for qid in problems:
         problems[qid]['caption'] = captions[qid] if qid in captions else ""
 
-    train_qids = pid_splits['%s' % (args.train_split)]
-    val_qids = pid_splits['%s' % (args.val_split)]
-    test_qids = pid_splits['%s' % (args.test_split)]
+    train_qids = pid_splits[f'{args.train_split}']
+    val_qids = pid_splits[f'{args.val_split}']
+    test_qids = pid_splits[f'{args.test_split}']
     print(f"number of train problems: {len(train_qids)}\n")
     print(f"number of val problems: {len(val_qids)}\n")
     print(f"number of test problems: {len(test_qids)}\n")

--- a/utils_evaluate.py
+++ b/utils_evaluate.py
@@ -18,7 +18,7 @@ def get_acc_with_contion(res_pd, key, values):
     else:
         total_pd = res_pd[res_pd[key] == values]
     correct_pd = total_pd[total_pd['true_false'] == True]
-    acc = "{:.2f}".format(len(correct_pd) / len(total_pd) * 100)
+    acc = f"{len(correct_pd) / len(total_pd) * 100:.2f}"
     return acc
 
 
@@ -86,7 +86,7 @@ def get_scores(result_data, rationale_data, results_reference, data_file):
                 'acc_grade_7_12':
                 get_acc_with_contion(res_pd, 'grade', ['grade7', 'grade8', 'grade9', 'grade10', 'grade11', 'grade12']),
                 'acc_average':
-                "{:.2f}".format(acc_average),
+                f"{acc_average:.2f}",
             },
             "rationale":{
                 'bleu1': bleu1 * 100,

--- a/utils_prompt.py
+++ b/utils_prompt.py
@@ -23,7 +23,7 @@ def get_choice_text(probelm, options):
     choices = probelm['choices']
     choice_list = []
     for i, c in enumerate(choices):
-        choice_list.append("({}) {}".format(options[i], c))
+        choice_list.append(f"({options[i]}) {c}")
     choice_txt = " ".join(choice_list)
     #print(choice_txt)
     return choice_txt


### PR DESCRIPTION
Reformats all the text from the old "%-formatted" and `.format()` formats to the newer f-string format, as defined in PEP 498. This requires Python 3.6+.

Flynt 0.76 was used to reformat the strings. 6 f-strings were created in 3 files.

F-strings are in general more readable, concise and performant. See also: https://www.python.org/dev/peps/pep-0498/#rationale