### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-huggingface-hub==0.0.12
+huggingface-hub>=0.4.0
 numpy==1.23.2
 openai==0.23.0
 pandas==1.4.3


### PR DESCRIPTION
Align with package requirements to solve install errors.

The install fails because packages have conflicting dependencies with those specified in requirements.txt

Changed huggingface-hub version from 0.0.12 to 0.4.0 to match the sentence-transformer dependency to allow installation of requirements.txt


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
