### PR TITLE
Convert Eager Logging to Lazy Logging

### DIFF
--- a/timm/data/config.py
+++ b/timm/data/config.py
@@ -73,6 +73,6 @@ def resolve_data_config(args, default_cfg={}, model=None, use_test_size=False, v
     if verbose:
         _logger.info('Data processing configuration for current model + dataset:')
         for n, v in new_config.items():
-            _logger.info('\t%s: %s' % (n, str(v)))
+            _logger.info('\t%s: %s', n, str(v))
 
     return new_config


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This codemod converts "eager" logging into "lazy" logging, which is preferred for performance efficiency and resource optimization.
Lazy logging defers the actual construction and formatting of log messages until it's confirmed that the message will be logged based on the current log level, thereby avoiding unnecessary computation for messages that will not be logged. 

Our changes look something like this:

```diff
import logging
e = "Some error"
- logging.error("Error occurred: %s" % e)
- logging.error("Error occurred: " + e)
+ logging.error("Error occurred: %s", e)
+ logging.error("Error occurred: %s", e)
```


Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/lazy-logging](https://docs.pixee.ai/codemods/python/pixee_python_lazy-logging)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixee-Bot-Python%2Fmm-cot%7C30e38ea70f721dd81d2a5c30d1ba58ac308c2afa)

<!--{"type":"DRIP","codemod":"pixee:python/lazy-logging"}-->

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
